### PR TITLE
fix: Build HTTPS redirect URI when behind LB

### DIFF
--- a/pkg/s3-proxy/server/utils/utils.go
+++ b/pkg/s3-proxy/server/utils/utils.go
@@ -168,7 +168,9 @@ func TemplateExecution(tplPath, tplString string, logger log.Logger, rw http.Res
 
 func GetRequestURI(r *http.Request) string {
 	scheme := "http"
-	if r.TLS != nil {
+	fwdScheme := r.Header.Get("X-Forwarded-Proto")
+
+	if r.TLS != nil || fwdScheme == "https" {
 		scheme = "https"
 	}
 

--- a/pkg/s3-proxy/server/utils/utils_test.go
+++ b/pkg/s3-proxy/server/utils/utils_test.go
@@ -939,6 +939,21 @@ func TestGetRequestURI(t *testing.T) {
 	}
 }
 
+func TestProxiedGetRequestURI(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://localhost:989/fake/path", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Add the same header a Load Balancer should set
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	want := "https://localhost:989/fake/path"
+	got := GetRequestURI(req)
+	if got != want {
+		t.Errorf("GetRequestURI() = %v, want %v", got, want)
+	}
+}
+
 func Test_RequestHost(t *testing.T) {
 	hXForwardedHost1 := http.Header{
 		"X-Forwarded-Host": []string{"fake.host"},


### PR DESCRIPTION
## Issue/Feature

When running `s3-proxy` behind a TLS-terminating Load Balancer, `s3-proxy` generates a `http://` value for
the OIDC `redirect_uri`. In HTTPS-only environments (or with secure cookies enabled), this causes the OIDC flow to fail.

This PR adds a simple check for the de-facto standard HTTP Header `X-Forwarded-Proto`. If this header is set and has value `https`, the `GetRequestURI` function will use the `https` scheme instead of `http`.

## Checklist:

- [ ] Verified by team member
- [ ] Tests were added
- [ ] Comments where necessary
- [ ] Documentation changes if necessary
