### PR TITLE
bugfix: Handle connection cancelation from client

### DIFF
--- a/pkg/s3-proxy/authx/authentication/basic-auth.go
+++ b/pkg/s3-proxy/authx/authentication/basic-auth.go
@@ -33,7 +33,7 @@ func (s *service) basicAuthMiddleware(res *config.Resource) func(http.Handler) h
 				if brctx == nil {
 					utils.HandleUnauthorized(logEntry, w, s.cfg.Templates, path)
 				} else {
-					brctx.HandleUnauthorized(path)
+					brctx.HandleUnauthorized(r.Context(), path)
 				}
 
 				return
@@ -51,7 +51,7 @@ func (s *service) basicAuthMiddleware(res *config.Resource) func(http.Handler) h
 				if brctx == nil {
 					utils.HandleUnauthorized(logEntry, w, s.cfg.Templates, path)
 				} else {
-					brctx.HandleUnauthorized(path)
+					brctx.HandleUnauthorized(r.Context(), path)
 				}
 
 				return
@@ -65,7 +65,7 @@ func (s *service) basicAuthMiddleware(res *config.Resource) func(http.Handler) h
 				if brctx == nil {
 					utils.HandleUnauthorized(logEntry, w, s.cfg.Templates, path)
 				} else {
-					brctx.HandleUnauthorized(path)
+					brctx.HandleUnauthorized(r.Context(), path)
 				}
 
 				return

--- a/pkg/s3-proxy/authx/authentication/main.go
+++ b/pkg/s3-proxy/authx/authentication/main.go
@@ -54,7 +54,7 @@ func (s *service) Middleware(resources []*config.Resource) func(http.Handler) ht
 				if brctx == nil {
 					utils.HandleInternalServerError(logEntry, w, s.cfg.Templates, requestURI, err)
 				} else {
-					brctx.HandleInternalServerError(err, requestURI)
+					brctx.HandleInternalServerError(r.Context(), err, requestURI)
 				}
 
 				return
@@ -69,7 +69,7 @@ func (s *service) Middleware(resources []*config.Resource) func(http.Handler) ht
 				if brctx == nil {
 					utils.HandleForbidden(logEntry, w, s.cfg.Templates, requestURI)
 				} else {
-					brctx.HandleForbidden(requestURI)
+					brctx.HandleForbidden(r.Context(), requestURI)
 				}
 
 				return
@@ -113,7 +113,7 @@ func (s *service) Middleware(resources []*config.Resource) func(http.Handler) ht
 			if brctx == nil {
 				utils.HandleInternalServerError(logEntry, w, s.cfg.Templates, requestURI, err)
 			} else {
-				brctx.HandleInternalServerError(err, requestURI)
+				brctx.HandleInternalServerError(r.Context(), err, requestURI)
 			}
 		})
 	}

--- a/pkg/s3-proxy/authx/authentication/oidc.go
+++ b/pkg/s3-proxy/authx/authentication/oidc.go
@@ -203,7 +203,7 @@ func (s *service) oidcAuthorizationMiddleware(res *config.Resource) func(http.Ha
 				if brctx == nil {
 					utils.HandleInternalServerError(logEntry, w, s.cfg.Templates, path, err)
 				} else {
-					brctx.HandleInternalServerError(err, path)
+					brctx.HandleInternalServerError(r.Context(), err, path)
 				}
 
 				return
@@ -238,7 +238,7 @@ func (s *service) oidcAuthorizationMiddleware(res *config.Resource) func(http.Ha
 				if brctx == nil {
 					utils.HandleInternalServerError(logEntry, w, s.cfg.Templates, path, err)
 				} else {
-					brctx.HandleInternalServerError(err, path)
+					brctx.HandleInternalServerError(r.Context(), err, path)
 				}
 
 				return
@@ -266,7 +266,7 @@ func (s *service) oidcAuthorizationMiddleware(res *config.Resource) func(http.Ha
 						if brctx == nil {
 							utils.HandleForbidden(logEntry, w, s.cfg.Templates, path)
 						} else {
-							brctx.HandleForbidden(path)
+							brctx.HandleForbidden(r.Context(), path)
 						}
 
 						return

--- a/pkg/s3-proxy/authx/authorization/main.go
+++ b/pkg/s3-proxy/authx/authorization/main.go
@@ -83,7 +83,7 @@ func Middleware(cfg *config.Config, metricsCl metrics.Client) func(http.Handler)
 						if brctx == nil {
 							utils.HandleInternalServerError(logger, w, cfg.Templates, requestURI, err)
 						} else {
-							brctx.HandleInternalServerError(err, requestURI)
+							brctx.HandleInternalServerError(r.Context(), err, requestURI)
 						}
 
 						return
@@ -100,7 +100,7 @@ func Middleware(cfg *config.Config, metricsCl metrics.Client) func(http.Handler)
 					if brctx == nil {
 						utils.HandleForbidden(logger, w, cfg.Templates, requestURI)
 					} else {
-						brctx.HandleForbidden(requestURI)
+						brctx.HandleForbidden(r.Context(), requestURI)
 					}
 
 					return
@@ -122,7 +122,7 @@ func Middleware(cfg *config.Config, metricsCl metrics.Client) func(http.Handler)
 			if brctx == nil {
 				utils.HandleInternalServerError(logger, w, cfg.Templates, requestURI, err)
 			} else {
-				brctx.HandleInternalServerError(err, requestURI)
+				brctx.HandleInternalServerError(r.Context(), err, requestURI)
 			}
 		})
 	}

--- a/pkg/s3-proxy/bucket/client.go
+++ b/pkg/s3-proxy/bucket/client.go
@@ -1,6 +1,7 @@
 package bucket
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -19,21 +20,21 @@ var ErrRemovalFolder = errors.New("can't remove folder")
 // Client represents a client in order to GET, PUT or DELETE file on a bucket with a html output.
 type Client interface {
 	// Get allow to GET what's inside a request path
-	Get(input *GetInput)
+	Get(ctx context.Context, input *GetInput)
 	// Put will put a file following input
-	Put(inp *PutInput)
+	Put(ctx context.Context, inp *PutInput)
 	// Delete will delete file on request path
-	Delete(requestPath string)
+	Delete(ctx context.Context, requestPath string)
 	// Handle not found errors with bucket configuration
-	HandleNotFound(requestPath string)
+	HandleNotFound(ctx context.Context, requestPath string)
 	// Handle forbidden errors with bucket configuration
-	HandleForbidden(requestPath string)
+	HandleForbidden(ctx context.Context, requestPath string)
 	// Handle bad request errors with bucket configuration
-	HandleBadRequest(err error, requestPath string)
+	HandleBadRequest(ctx context.Context, err error, requestPath string)
 	// Handle internal server error errors with bucket configuration
-	HandleInternalServerError(err error, requestPath string)
+	HandleInternalServerError(ctx context.Context, err error, requestPath string)
 	// Handle unauthorized errors with bucket configuration
-	HandleUnauthorized(requestPath string)
+	HandleUnauthorized(ctx context.Context, requestPath string)
 }
 
 // GetInput represents Get input.

--- a/pkg/s3-proxy/bucket/error_management.go
+++ b/pkg/s3-proxy/bucket/error_management.go
@@ -1,8 +1,11 @@
 package bucket
 
-import "path"
+import (
+	"context"
+	"path"
+)
 
-func (rctx *requestContext) HandleInternalServerError(err error, requestPath string) {
+func (rctx *requestContext) HandleInternalServerError(ctx context.Context, err error, requestPath string) {
 	// Initialize content
 	content := ""
 	// Check if file is in bucket
@@ -11,7 +14,7 @@ func (rctx *requestContext) HandleInternalServerError(err error, requestPath str
 		rctx.targetCfg.Templates.InternalServerError != nil {
 		// Put error err2 to avoid erase of err
 		var err2 error
-		content, err2 = rctx.loadTemplateContent(rctx.targetCfg.Templates.InternalServerError)
+		content, err2 = rctx.loadTemplateContent(ctx, rctx.targetCfg.Templates.InternalServerError)
 		// Check if error exists
 		if err2 != nil {
 			// This is a particular case. In this case, remove old error and manage new one
@@ -23,7 +26,7 @@ func (rctx *requestContext) HandleInternalServerError(err error, requestPath str
 	rctx.errorsHandlers.HandleInternalServerErrorWithTemplate(rctx.logger, rctx.httpRW, rctx.tplConfig, content, rpath, err)
 }
 
-func (rctx *requestContext) HandleNotFound(requestPath string) {
+func (rctx *requestContext) HandleNotFound(ctx context.Context, requestPath string) {
 	// Initialize content
 	content := ""
 	// Check if file is in bucket
@@ -33,9 +36,9 @@ func (rctx *requestContext) HandleNotFound(requestPath string) {
 		// Declare error
 		var err error
 		// Try to get file from bucket
-		content, err = rctx.loadTemplateContent(rctx.targetCfg.Templates.NotFound)
+		content, err = rctx.loadTemplateContent(ctx, rctx.targetCfg.Templates.NotFound)
 		if err != nil {
-			rctx.HandleInternalServerError(err, requestPath)
+			rctx.HandleInternalServerError(ctx, err, requestPath)
 
 			return
 		}
@@ -45,7 +48,7 @@ func (rctx *requestContext) HandleNotFound(requestPath string) {
 	rctx.errorsHandlers.HandleNotFoundWithTemplate(rctx.logger, rctx.httpRW, rctx.tplConfig, content, rpath)
 }
 
-func (rctx *requestContext) HandleForbidden(requestPath string) {
+func (rctx *requestContext) HandleForbidden(ctx context.Context, requestPath string) {
 	// Initialize content
 	content := ""
 	// Check if file is in bucket
@@ -55,9 +58,9 @@ func (rctx *requestContext) HandleForbidden(requestPath string) {
 		// Declare error
 		var err error
 		// Try to get file from bucket
-		content, err = rctx.loadTemplateContent(rctx.targetCfg.Templates.Forbidden)
+		content, err = rctx.loadTemplateContent(ctx, rctx.targetCfg.Templates.Forbidden)
 		if err != nil {
-			rctx.HandleInternalServerError(err, requestPath)
+			rctx.HandleInternalServerError(ctx, err, requestPath)
 
 			return
 		}
@@ -67,7 +70,7 @@ func (rctx *requestContext) HandleForbidden(requestPath string) {
 	rctx.errorsHandlers.HandleForbiddenWithTemplate(rctx.logger, rctx.httpRW, rctx.tplConfig, content, rpath)
 }
 
-func (rctx *requestContext) HandleBadRequest(err error, requestPath string) {
+func (rctx *requestContext) HandleBadRequest(ctx context.Context, err error, requestPath string) {
 	// Initialize content
 	content := ""
 	// Check if file is in bucket
@@ -77,9 +80,9 @@ func (rctx *requestContext) HandleBadRequest(err error, requestPath string) {
 		// Declare error
 		var err2 error
 		// Try to get file from bucket
-		content, err2 = rctx.loadTemplateContent(rctx.targetCfg.Templates.BadRequest)
+		content, err2 = rctx.loadTemplateContent(ctx, rctx.targetCfg.Templates.BadRequest)
 		if err2 != nil {
-			rctx.HandleInternalServerError(err2, requestPath)
+			rctx.HandleInternalServerError(ctx, err2, requestPath)
 
 			return
 		}
@@ -89,7 +92,7 @@ func (rctx *requestContext) HandleBadRequest(err error, requestPath string) {
 	rctx.errorsHandlers.HandleBadRequestWithTemplate(rctx.logger, rctx.httpRW, rctx.tplConfig, content, rpath, err)
 }
 
-func (rctx *requestContext) HandleUnauthorized(requestPath string) {
+func (rctx *requestContext) HandleUnauthorized(ctx context.Context, requestPath string) {
 	// Initialize content
 	content := ""
 	// Check if file is in bucket
@@ -99,9 +102,9 @@ func (rctx *requestContext) HandleUnauthorized(requestPath string) {
 		// Declare error
 		var err error
 		// Try to get file from bucket
-		content, err = rctx.loadTemplateContent(rctx.targetCfg.Templates.Unauthorized)
+		content, err = rctx.loadTemplateContent(ctx, rctx.targetCfg.Templates.Unauthorized)
 		if err != nil {
-			rctx.HandleInternalServerError(err, requestPath)
+			rctx.HandleInternalServerError(ctx, err, requestPath)
 
 			return
 		}

--- a/pkg/s3-proxy/s3client/client.go
+++ b/pkg/s3-proxy/s3client/client.go
@@ -1,6 +1,7 @@
 package s3client
 
 import (
+	"context"
 	"errors"
 	"io"
 	"time"
@@ -17,11 +18,11 @@ import (
 
 // Client S3 Context interface.
 type Client interface {
-	ListFilesAndDirectories(key string) ([]*ListElementOutput, error)
-	HeadObject(key string) (*HeadOutput, error)
-	GetObject(input *GetInput) (*GetOutput, error)
-	PutObject(input *PutInput) error
-	DeleteObject(key string) error
+	ListFilesAndDirectories(ctx context.Context, key string) ([]*ListElementOutput, error)
+	HeadObject(ctx context.Context, key string) (*HeadOutput, error)
+	GetObject(ctx context.Context, input *GetInput) (*GetOutput, error)
+	PutObject(ctx context.Context, input *PutInput) error
+	DeleteObject(ctx context.Context, key string) error
 }
 
 // FileType File type.

--- a/pkg/s3-proxy/server/server.go
+++ b/pkg/s3-proxy/server/server.go
@@ -245,7 +245,7 @@ func (svr *Server) generateRouter() (http.Handler, error) {
 							ifModifiedSinceTime, err := http.ParseTime(ifModifiedSinceStr)
 							// Check error
 							if err != nil {
-								brctx.HandleBadRequest(err, requestPath)
+								brctx.HandleBadRequest(req.Context(), err, requestPath)
 
 								return
 							}
@@ -272,7 +272,7 @@ func (svr *Server) generateRouter() (http.Handler, error) {
 							ifUnmodifiedSinceTime, err := http.ParseTime(ifUnmodifiedSinceStr)
 							// Check error
 							if err != nil {
-								brctx.HandleBadRequest(err, requestPath)
+								brctx.HandleBadRequest(req.Context(), err, requestPath)
 
 								return
 							}
@@ -281,14 +281,16 @@ func (svr *Server) generateRouter() (http.Handler, error) {
 						}
 
 						// Proxy GET Request
-						brctx.Get(&bucket.GetInput{
-							RequestPath:       requestPath,
-							IfModifiedSince:   ifModifiedSince,
-							IfMatch:           ifMatch,
-							IfNoneMatch:       ifNoneMatch,
-							IfUnmodifiedSince: ifUnmodifiedSince,
-							Range:             byteRange,
-						})
+						brctx.Get(
+							req.Context(),
+							&bucket.GetInput{
+								RequestPath:       requestPath,
+								IfModifiedSince:   ifModifiedSince,
+								IfMatch:           ifMatch,
+								IfNoneMatch:       ifNoneMatch,
+								IfUnmodifiedSince: ifUnmodifiedSince,
+								Range:             byteRange,
+							})
 					})
 				}
 
@@ -304,7 +306,7 @@ func (svr *Server) generateRouter() (http.Handler, error) {
 						logEntry := middlewares.GetLogEntry(req)
 						if err := req.ParseForm(); err != nil {
 							logEntry.Error(err)
-							brctx.HandleInternalServerError(err, path)
+							brctx.HandleInternalServerError(req.Context(), err, path)
 
 							return
 						}
@@ -312,7 +314,7 @@ func (svr *Server) generateRouter() (http.Handler, error) {
 						err := req.ParseMultipartForm(0)
 						if err != nil {
 							logEntry.Error(err)
-							brctx.HandleInternalServerError(err, path)
+							brctx.HandleInternalServerError(req.Context(), err, path)
 
 							return
 						}
@@ -320,7 +322,7 @@ func (svr *Server) generateRouter() (http.Handler, error) {
 						file, fileHeader, err := req.FormFile("file")
 						if err != nil {
 							logEntry.Error(err)
-							brctx.HandleInternalServerError(err, path)
+							brctx.HandleInternalServerError(req.Context(), err, path)
 
 							return
 						}
@@ -332,7 +334,7 @@ func (svr *Server) generateRouter() (http.Handler, error) {
 							ContentType: fileHeader.Header.Get("Content-Type"),
 							ContentSize: fileHeader.Size,
 						}
-						brctx.Put(inp)
+						brctx.Put(req.Context(), inp)
 					})
 				}
 
@@ -345,7 +347,7 @@ func (svr *Server) generateRouter() (http.Handler, error) {
 						// Get request path
 						requestPath := chi.URLParam(req, "*")
 						// Proxy GET Request
-						brctx.Delete(requestPath)
+						brctx.Delete(req.Context(), requestPath)
 					})
 				}
 			})


### PR DESCRIPTION
In case the client is dropping the connection, we do not cancel the requests made to the S3 backend.
Proposed fix is to forward the context coming from the client request to the AWS SDK.