### PR TITLE
Makes Docker image self-buildable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+s3-proxy
+vendor/
+bin/
+config.yaml
+dist/
+_dist/
+coverage.html
+bundle.tar.gz
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+FROM golang:1.17-alpine
+WORKDIR /src/
+COPY . /src
+RUN apk add -U make bash curl git && make code/build
+
 FROM alpine:3.16
 
 ENV USER=proxy
@@ -10,11 +15,12 @@ RUN apk add --update ca-certificates && rm -rf /var/cache/apk/* && \
 
 WORKDIR /proxy
 
-COPY s3-proxy /proxy/s3-proxy
+COPY --from=0 /src/bin/s3-proxy /proxy/s3-proxy
 COPY templates/ /proxy/templates/
 
 RUN chown -R 1000:1000 /proxy
 
 USER proxy
 
+EXPOSE 8080
 ENTRYPOINT [ "/proxy/s3-proxy" ]


### PR DESCRIPTION
---
name: Pull request
about: Pull request for this project
title: "Makes Docker image self-buildable"
labels: ""
assignees: ""
---

## Issue/Feature

<!-- Add any information needed. Such as the GH issue this PR relates to or any other context you feel is necessary.) -->

I do not want to build s3-proxy on my host computer, but only as a docker image. This addition creates a multi-stage Dockerfile to build the s3-proxy binary and make an image in one step. 

## Additional Information

<!-- What/Why/How or any other context you feel is necessary.) -->

This does not require you to prebuild the s3-proxy binary.  To build a Docker image from scratch, just run:

```
docker build -t s3-proxy .
```

## Verification Steps

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:

- [ ] Verified by team member
- [ ] Tests were added
- [ ] Comments where necessary
- [ ] Documentation changes if necessary
