### PR TITLE
feat: add version command and allow config path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.18.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
 	github.com/thoas/go-funk v0.9.3
@@ -50,6 +51,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-oidc/v3 v3.9.0 h1:0J/ogVOd4y8P0f0xUh8l9t07xRP/d8tccvjHl2dcsSo=
 github.com/coreos/go-oidc/v3 v3.9.0/go.mod h1:rTKz2PYwftcrtoCzV5g5kvfJoWcm0Mk8AF8y1iAQro4=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -82,6 +83,8 @@ github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -128,6 +131,7 @@ github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3c
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 h1:GHRpF1pTW19a8tTFrMLUcfWwyC0pnifVo2ClaLq+hP8=
 github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46/go.mod h1:uAQ5PCi+MFsC7HjREoAz1BU+Mq60+05gifQSsHSDG/8=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
@@ -150,6 +154,8 @@ github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNo
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=

--- a/pkg/s3-proxy/config/manager.go
+++ b/pkg/s3-proxy/config/manager.go
@@ -7,7 +7,7 @@ import "github.com/oxyno-zeta/s3-proxy/pkg/s3-proxy/log"
 //go:generate mockgen -destination=./mocks/mock_Manager.go -package=mocks github.com/oxyno-zeta/s3-proxy/pkg/s3-proxy/config Manager
 type Manager interface {
 	// Load configuration
-	Load() error
+	Load(mainConfDir string) error
 	// Get configuration object
 	GetConfig() *Config
 	// Add on change hook for configuration change

--- a/pkg/s3-proxy/config/managerimpl.go
+++ b/pkg/s3-proxy/config/managerimpl.go
@@ -20,9 +20,6 @@ import (
 	"github.com/thoas/go-funk"
 )
 
-// Main configuration folder path.
-var mainConfigFolderPath = "conf/"
-
 var validate = validator.New()
 
 type managerimpl struct {
@@ -37,15 +34,15 @@ func (impl *managerimpl) AddOnChangeHook(hook func()) {
 	impl.onChangeHooks = append(impl.onChangeHooks, hook)
 }
 
-func (impl *managerimpl) Load() error {
+func (impl *managerimpl) Load(mainConfDir string) error {
 	// List files
-	files, err := os.ReadDir(mainConfigFolderPath)
+	files, err := os.ReadDir(mainConfDir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
 	// Generate viper instances for static configs
-	impl.configs = generateViperInstances(files)
+	impl.configs = generateViperInstances(files, mainConfDir)
 
 	// Load configuration
 	err = impl.loadConfiguration()
@@ -191,7 +188,7 @@ func (*managerimpl) loadDefaultConfigurationValues(vip *viper.Viper) {
 	vip.SetDefault("templates.delete.status", DefaultTemplateStatusNoContent)
 }
 
-func generateViperInstances(files []os.DirEntry) []*viper.Viper {
+func generateViperInstances(files []os.DirEntry, mainConfDir string) []*viper.Viper {
 	list := make([]*viper.Viper, 0)
 	// Loop over static files to create viper instance for them
 	funk.ForEach(files, func(file os.DirEntry) {
@@ -205,7 +202,7 @@ func generateViperInstances(files []os.DirEntry) []*viper.Viper {
 			// Set config name
 			vip.SetConfigName(cfgFileName)
 			// Add configuration path
-			vip.AddConfigPath(mainConfigFolderPath)
+			vip.AddConfigPath(mainConfDir)
 			// Append it
 			list = append(list, vip)
 		}

--- a/pkg/s3-proxy/config/managerimpl_integration_test.go
+++ b/pkg/s3-proxy/config/managerimpl_integration_test.go
@@ -1520,15 +1520,12 @@ targets:
 				defer os.Remove(k)
 			}
 
-			// Change var for main configuration file
-			mainConfigFolderPath = dir
-
 			ctx := &managerimpl{
 				logger: log.NewLogger(),
 			}
 
 			// Load config
-			err = ctx.Load()
+			err = ctx.Load(dir)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
@@ -1601,9 +1598,6 @@ targets:
 		defer os.Remove(k)
 	}
 
-	// Change var for main configuration file
-	mainConfigFolderPath = dir
-
 	ctx := &managerimpl{
 		logger: log.NewLogger(),
 	}
@@ -1613,7 +1607,7 @@ targets:
 	})
 
 	// Load config
-	err = ctx.Load()
+	err = ctx.Load(dir)
 	assert.NoError(t, err)
 	// Get configuration
 	res := ctx.GetConfig()
@@ -1806,9 +1800,6 @@ targets:
 		defer os.Remove(k)
 	}
 
-	// Change var for main configuration file
-	mainConfigFolderPath = dir
-
 	ctx := &managerimpl{
 		logger: log.NewLogger(),
 	}
@@ -1818,7 +1809,7 @@ targets:
 	})
 
 	// Load config
-	err = ctx.Load()
+	err = ctx.Load(dir)
 	assert.NoError(t, err)
 	// Get configuration
 	res := ctx.GetConfig()
@@ -2008,9 +1999,6 @@ targets:
 		defer os.Remove(k)
 	}
 
-	// Change var for main configuration file
-	mainConfigFolderPath = dir
-
 	ctx := &managerimpl{
 		logger: log.NewLogger(),
 	}
@@ -2020,7 +2008,7 @@ targets:
 	})
 
 	// Load config
-	err = ctx.Load()
+	err = ctx.Load(dir)
 	assert.NoError(t, err)
 	// Get configuration
 	res := ctx.GetConfig()
@@ -2217,9 +2205,6 @@ targets:
 		defer os.Remove(k)
 	}
 
-	// Change var for main configuration file
-	mainConfigFolderPath = dir
-
 	ctx := &managerimpl{
 		logger: log.NewLogger(),
 	}
@@ -2229,7 +2214,7 @@ targets:
 	})
 
 	// Load config
-	err = ctx.Load()
+	err = ctx.Load(dir)
 	assert.NoError(t, err)
 	// Get configuration
 	res := ctx.GetConfig()
@@ -2451,9 +2436,6 @@ targets:
 		defer os.Remove(k)
 	}
 
-	// Change var for main configuration file
-	mainConfigFolderPath = dir
-
 	ctx := &managerimpl{
 		logger: log.NewLogger(),
 	}
@@ -2463,7 +2445,7 @@ targets:
 	})
 
 	// Load config
-	err = ctx.Load()
+	err = ctx.Load(dir)
 	assert.NoError(t, err)
 	// Get configuration
 	res := ctx.GetConfig()

--- a/pkg/s3-proxy/config/mocks/mock_Manager.go
+++ b/pkg/s3-proxy/config/mocks/mock_Manager.go
@@ -66,15 +66,15 @@ func (mr *MockManagerMockRecorder) GetConfig() *gomock.Call {
 }
 
 // Load mocks base method.
-func (m *MockManager) Load() error {
+func (m *MockManager) Load(arg0 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Load")
+	ret := m.ctrl.Call(m, "Load", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Load indicates an expected call of Load.
-func (mr *MockManagerMockRecorder) Load() *gomock.Call {
+func (mr *MockManagerMockRecorder) Load(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockManager)(nil).Load))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockManager)(nil).Load), arg0)
 }


### PR DESCRIPTION
## Issue/Feature

- Add a new command to the app in the form of the `version` command that allows to easily see what version of the package we're using. Previously this was only visible when the server was starting.
- Add a new parameter that would allow the user to specify the configuration folder to use. The default value is still `conf/`, but now we can also specify the path we want.

## Additional Information

Nothing is suppose to break, as the usage stay the same : Not specifying any command will start the server, just like it's currently done, and the default value for the configuration folder is also still the same. If I missed anything, please let me know.

The only downside of this PR is that it adds a new dependencies to the project in the form of Cobra.

## Checklist:

- [ ] Verified by team member
- [ ] Tests were added
- [ ] Comments where necessary
- [ ] Documentation changes if necessary
