### PR TITLE
build: publish docker images to ghcr.io

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,7 +89,8 @@ dockers:
     ids:
       - s3-proxy
     image_templates:
-      - "oxynozeta/s3-proxy:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-amd64"
     skip_push: false
     use: buildx
     dockerfile: Dockerfile
@@ -105,7 +106,8 @@ dockers:
     ids:
       - s3-proxy
     image_templates:
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv6"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv6"
     skip_push: false
     use: buildx
     dockerfile: Dockerfile
@@ -121,7 +123,8 @@ dockers:
     ids:
       - s3-proxy
     image_templates:
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv7"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv7"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv7"
     skip_push: false
     use: buildx
     dockerfile: Dockerfile
@@ -136,7 +139,8 @@ dockers:
     ids:
       - s3-proxy
     image_templates:
-      - "oxynozeta/s3-proxy:{{ .Version }}-arm64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-arm64"
     skip_push: false
     use: buildx
     dockerfile: Dockerfile
@@ -148,27 +152,51 @@ dockers:
       - templates/
 
 docker_manifests:
-  - name_template: oxynozeta/s3-proxy:latest
+  - name_template: "{{ .Env.DOCKERHUB_REPO }}:latest"
     image_templates:
-      - "oxynozeta/s3-proxy:{{ .Version }}-amd64"
-      - "oxynozeta/s3-proxy:{{ .Version }}-arm64"
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv6"
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv7"
-  - name_template: "oxynozeta/s3-proxy:{{ .Version }}"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv7"
+  - name_template: "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}"
     image_templates:
-      - "oxynozeta/s3-proxy:{{ .Version }}-amd64"
-      - "oxynozeta/s3-proxy:{{ .Version }}-arm64"
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv6"
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv7"
-  - name_template: "oxynozeta/s3-proxy:{{ .Major }}"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv7"
+  - name_template: "{{ .Env.DOCKERHUB_REPO }}:{{ .Major }}"
     image_templates:
-      - "oxynozeta/s3-proxy:{{ .Version }}-amd64"
-      - "oxynozeta/s3-proxy:{{ .Version }}-arm64"
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv6"
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv7"
-  - name_template: "oxynozeta/s3-proxy:{{ .Major }}.{{ .Minor }}"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv7"
+  - name_template: "{{ .Env.DOCKERHUB_REPO }}:{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "oxynozeta/s3-proxy:{{ .Version }}-amd64"
-      - "oxynozeta/s3-proxy:{{ .Version }}-arm64"
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv6"
-      - "oxynozeta/s3-proxy:{{ .Version }}-armv7"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.DOCKERHUB_REPO }}:{{ .Version }}-armv7"
+  - name_template: "{{ .Env.GHCR_REPO }}:latest"
+    image_templates:
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv7"
+  - name_template: "{{ .Env.GHCR_REPO }}:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv7"
+  - name_template: "{{ .Env.GHCR_REPO }}:{{ .Major }}"
+    image_templates:
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv7"
+  - name_template: "{{ .Env.GHCR_REPO }}:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-amd64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-arm64"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv6"
+      - "{{ .Env.GHCR_REPO }}:{{ .Version }}-armv7"

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ LDFLAGS += -X ${PKG}/pkg/${PROJECT_NAME}/version.Version=${BINARY_VERSION}
 LDFLAGS += -X ${PKG}/pkg/${PROJECT_NAME}/version.GitCommit=${GIT_COMMIT}
 LDFLAGS += -X ${PKG}/pkg/${PROJECT_NAME}/version.BuildDate=${DATE}
 
+DOCKERHUB_REPO := oxynozeta/s3-proxy
+GHCR_REPO      := ghcr.io/oxyno-zeta/s3-proxy
+export DOCKERHUB_REPO
+export GHCR_REPO
+
 HAS_GORELEASER := $(shell command -v goreleaser;)
 HAS_GIT := $(shell command -v git;)
 HAS_GOLANGCI_LINT := $(shell command -v golangci-lint;)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <p align="center">
   <a href="https://coveralls.io/github/oxyno-zeta/s3-proxy?branch=master" rel="noopener noreferer" target="_blank"><img src="https://coveralls.io/repos/github/oxyno-zeta/s3-proxy/badge.svg?branch=master" alt="Coverage Status" /></a>
   <a href="https://hub.docker.com/r/oxynozeta/s3-proxy" rel="noopener noreferer" target="_blank"><img src="https://img.shields.io/docker/pulls/oxynozeta/s3-proxy.svg" alt="Docker Pulls" /></a>
+  <a href="https://github.com/oxyno-zeta/s3-proxy/pkgs/container/s3-proxy" rel="noopener noreferer" target="_blank"><img src="https://img.shields.io/badge/ghcr.io-s3--proxy-blue.svg" alt="GHCR" /></a>
   <a href="https://github.com/oxyno-zeta/s3-proxy/blob/master/LICENSE" rel="noopener noreferer" target="_blank"><img src="https://img.shields.io/github/license/oxyno-zeta/s3-proxy" alt="GitHub license" /></a>
   <a href="https://github.com/oxyno-zeta/s3-proxy/releases" rel="noopener noreferer" target="_blank"><img src="https://img.shields.io/github/v/release/oxyno-zeta/s3-proxy" alt="GitHub release (latest by date)" /></a>
 </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 <p align="center">
   <a href="https://coveralls.io/github/oxyno-zeta/s3-proxy?branch=master" rel="noopener noreferer" target="_blank"><img src="https://coveralls.io/repos/github/oxyno-zeta/s3-proxy/badge.svg?branch=master" alt="Coverage Status" /></a>
   <a href="https://hub.docker.com/r/oxynozeta/s3-proxy" rel="noopener noreferer" target="_blank"><img src="https://img.shields.io/docker/pulls/oxynozeta/s3-proxy.svg" alt="Docker Pulls" /></a>
+  <a href="https://github.com/oxyno-zeta/s3-proxy/pkgs/container/s3-proxy" rel="noopener noreferer" target="_blank"><img src="https://img.shields.io/badge/ghcr.io-s3--proxy-blue.svg" alt="GHCR" /></a>
   <a href="https://github.com/oxyno-zeta/s3-proxy/blob/master/LICENSE" rel="noopener noreferer" target="_blank"><img src="https://img.shields.io/github/license/oxyno-zeta/s3-proxy" alt="GitHub license" /></a>
   <a href="https://github.com/oxyno-zeta/s3-proxy/releases" rel="noopener noreferer" target="_blank"><img src="https://img.shields.io/github/v/release/oxyno-zeta/s3-proxy" alt="GitHub release (latest by date)" /></a>
 </p>

--- a/docs/user-guide/deployment.md
+++ b/docs/user-guide/deployment.md
@@ -26,3 +26,5 @@ Run this command:
 ```bash
 docker run -d --name s3-proxy -p 8080:8080 -p 9090:9090 -v $PWD/conf:/proxy/conf oxynozeta/s3-proxy
 ```
+
+The image is also published to GitHub Container Registry as `ghcr.io/oxyno-zeta/s3-proxy`, interchangeable with the Docker Hub image above.


### PR DESCRIPTION
## Issue/Feature

No linked issue — this is a suggestion, opened directly as a PR rather than an issue first, happy to adjust based on maintainer preference or split into smaller pieces if preferred.

Publishes the same multi-arch images to `ghcr.io/oxyno-zeta/s3-proxy` alongside the existing `oxynozeta/s3-proxy` Docker Hub images. Motivation: Docker Hub's anonymous pull limit dropped to 10 pulls/hour as of April 2025. ghcr.io doesn't impose an equivalent limit on public images, so this gives users an unthrottled alternative.

## Additional Information

**What/How:** the registry namespace for each target is defined once, in the `Makefile` (`DOCKERHUB_REPO`, `GHCR_REPO`), and referenced via `{{ .Env.* }}` throughout `.goreleaser.yaml` instead of being spelled out repeatedly across every arch/tag combination. This also removes the risk of the `oxynozeta` (Docker Hub) / `oxyno-zeta` (GitHub org) naming difference drifting out of sync across templates. Both vars are exported at the top of the `Makefile` (not inlined on a single recipe line) because two targets render these templates — `release/all` and `code/build-cross` (used by CI's `build-cross` job via `goreleaser --snapshot`) — and inlining on just one would leave the other rendering an empty registry.

**Before cutting a release with this merged:** whoever runs `make release/all` will need to be logged in to ghcr.io in addition to Docker Hub:

1. Create a GitHub Personal Access Token with `write:packages` scope (classic PAT at github.com/settings/tokens, or a fine-grained PAT with "Packages: write" permission on this repo/org).
2. `echo $TOKEN | docker login ghcr.io -u <github-username> --password-stdin`
3. Confirm the login persists in your local Docker credential store before cutting the next release.

**A limitation worth knowing about (not addressed here):** releases are cut via `semantic-release`, which creates the git tag and GitHub Release *before* invoking `make release/all` → `goreleaser`. From what I understand, because cutting the release isn't separated from publishing images, a failure during publishing (e.g. not being logged in to ghcr.io) could leave the process with partially published images, and the release process doesn't look safely retryable in that case.

A more robust design would decouple cutting the release (versioning, changelog, GitHub Release) from pushing images, so publishing could be retried on its own without redoing the release. That's a bigger change than this PR and out of scope here — flagging it in case it's useful for prioritizing future work.

## Verification Steps

1. Run `goreleaser check` against `.goreleaser.yaml` — confirms the config parses and the new `dockers`/`docker_manifests` entries are valid.
2. Run `DOCKERHUB_REPO=oxynozeta/s3-proxy GHCR_REPO=ghcr.io/oxyno-zeta/s3-proxy make code/build-cross` locally — a snapshot build that renders every `image_templates`/`docker_manifests` entry (including the CI path) without pushing, confirming both registries' tags render correctly.
3. Full end-to-end verification (an actual push to ghcr.io) requires the ghcr.io login above and can only really be confirmed on the next real release.

## Checklist:

- [ ] Verified by team member
- [ ] Tests were added _(N/A — config-only change to `.goreleaser.yaml`/`Makefile`, no Go code touched; see Verification Steps above instead)_
- [ ] Comments where necessary _(none added — none needed, the env var names document intent)_
- [x] Documentation changes if necessary _(added a ghcr.io badge/link in `README.md` and `docs/index.md`, and a one-line mention in `docs/user-guide/deployment.md`)_
