### PR TITLE
fix(response-handler): return 206 for range requests covering the whole object

### DIFF
--- a/pkg/s3-proxy/response-handler/utils.go
+++ b/pkg/s3-proxy/response-handler/utils.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 
 	"emperror.dev/errors"
@@ -122,42 +121,16 @@ func setHeadersFromObjectOutput(w http.ResponseWriter, obj *models.StreamInput) 
 }
 
 func determineHTTPStatus(obj *models.StreamInput) int {
-	contentRangeIsGiven := len(obj.ContentRange) > 0
-	// Check if content will be partial
-	if contentRangeIsGiven {
-		if !totalFileSizeEqualToContentRange(obj) {
-			// Return partial content
-			return http.StatusPartialContent
-		}
+	// Content-Range is only set when S3 itself answered 206. Mirror that status
+	// even when the range covers the whole object: RFC 9110 forbids Content-Range
+	// on a 200 response, and clients like Safari treat 200 as "ranges unsupported".
+	if len(obj.ContentRange) > 0 {
+		// Return partial content
+		return http.StatusPartialContent
 	}
 
 	// Return ok
 	return http.StatusOK
-}
-
-func totalFileSizeEqualToContentRange(obj *models.StreamInput) bool {
-	totalSizeIsEqualToContentRange := false
-	// Calculate total file size
-	totalSize, err := strconv.ParseInt(getFileSizeAsString(obj), 10, 64)
-	if err == nil {
-		if totalSize == (obj.ContentLength) {
-			totalSizeIsEqualToContentRange = true
-		}
-	}
-	// Return result
-	return totalSizeIsEqualToContentRange
-}
-
-/*
-*
-See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range
-*/
-func getFileSizeAsString(obj *models.StreamInput) string {
-	s := strings.Split(obj.ContentRange, "/")
-	totalSizeString := s[1]
-	totalSizeString = strings.TrimSpace(totalSizeString)
-	// Return result
-	return totalSizeString
 }
 
 func setStrHeader(w http.ResponseWriter, key, value string) {

--- a/pkg/s3-proxy/response-handler/utils_test.go
+++ b/pkg/s3-proxy/response-handler/utils_test.go
@@ -164,7 +164,7 @@ func Test_setHeadersFromObjectOutput(t *testing.T) {
 	headerFullInput.Add("Content-Encoding", "contentencoding")
 	headerFullInput.Add("Content-Language", "contentlanguage")
 	headerFullInput.Add("Content-Length", "200")
-	headerFullInput.Add("Content-Range", "bytes 200/200")
+	headerFullInput.Add("Content-Range", "bytes 0-199/200")
 	headerFullInput.Add("Content-Type", "contenttype")
 	headerFullInput.Add("ETag", "etag")
 	headerFullInput.Add("Accept-Ranges", "bytes")
@@ -209,14 +209,14 @@ func Test_setHeadersFromObjectOutput(t *testing.T) {
 					ContentEncoding:    "contentencoding",
 					ContentLanguage:    "contentlanguage",
 					ContentLength:      200,
-					ContentRange:       "bytes 200/200",
+					ContentRange:       "bytes 0-199/200",
 					ContentType:        "contenttype",
 					ETag:               "etag",
 					LastModified:       now,
 				},
 			},
 			expectedHeaders: headerFullInput,
-			expectedCode:    http.StatusOK,
+			expectedCode:    http.StatusPartialContent,
 		},
 		{
 			name: "Partial input",
@@ -247,7 +247,7 @@ func Test_setHeadersFromObjectOutput(t *testing.T) {
 					ContentEncoding:    "contentencoding",
 					ContentLanguage:    "contentlanguage",
 					ContentLength:      200,
-					ContentRange:       "bytes 200/200",
+					ContentRange:       "bytes 0-199/200",
 					ContentType:        "contenttype",
 					ContentDigest:      "sha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:",
 					ETag:               "etag",
@@ -262,7 +262,7 @@ func Test_setHeadersFromObjectOutput(t *testing.T) {
 				h.Add("Content-Encoding", "contentencoding")
 				h.Add("Content-Language", "contentlanguage")
 				h.Add("Content-Length", "200")
-				h.Add("Content-Range", "bytes 200/200")
+				h.Add("Content-Range", "bytes 0-199/200")
 				h.Add("Content-Type", "contenttype")
 				h.Add("ETag", "etag")
 				h.Add("Accept-Ranges", "bytes")
@@ -270,7 +270,7 @@ func Test_setHeadersFromObjectOutput(t *testing.T) {
 				h.Add("Content-Digest", "sha-256=:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=:")
 				return h
 			}(),
-			expectedCode: http.StatusOK,
+			expectedCode: http.StatusPartialContent,
 		},
 
 	}


### PR DESCRIPTION
Fixes #740

**Describe the pull request**

`determineHTTPStatus()` rewrote the response status to `200 OK` when the requested range covered the entire object (e.g. `Range: bytes=0-`), while the `Content-Range` header was still sent. This combination is invalid per RFC 9110 (a `200` response must not carry `Content-Range`, [§14.4](https://www.rfc-editor.org/rfc/rfc9110#section-14.4); a satisfied range request must be answered with `206`, [§15.3.7](https://www.rfc-editor.org/rfc/rfc9110#section-15.3.7)).

Practical impact: Safari/AVFoundation starts every video with `Range: bytes=0-`, treats the `200` answer as "range requests unsupported" and falls back to fetching the file in tiny sequential chunks, which effectively breaks progressive video playback through s3-proxy (the original use case Range support was added for in #182).

The fix mirrors S3: `Content-Range` is only present on a `StreamInput` when S3 itself answered `206`, so s3-proxy now answers `206` in that case too. The now-unused helpers `totalFileSizeEqualToContentRange()` and `getFileSizeAsString()` are removed. Plain `GET` responses without a `Range` are unaffected and still answered with `200`.

Unit tests updated accordingly: cases with a `Content-Range` set now expect `206`, and the header value used in fixtures is changed from the malformed `bytes 200/200` to a valid full-span `bytes 0-199/200` to document the exact scenario being fixed.

Verified against a live S3 backend:

```
Range: bytes=0-          -> 206 Partial Content (was 200)
Range: bytes=0-5907519   -> 206 Partial Content (was 200)
Range: bytes=0-1023      -> 206 Partial Content (unchanged)
Range: bytes=100-200     -> 206 Partial Content (unchanged)
no Range                 -> 200 OK              (unchanged)
```